### PR TITLE
workflow-tasks-cleaner: robustness fixes + first unit tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,18 @@
             <version>3.4.0</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.13.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>3.24.2</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/org/jahia/community/workflowtaskscleaner/CleanCommand.java
+++ b/src/main/java/org/jahia/community/workflowtaskscleaner/CleanCommand.java
@@ -75,7 +75,7 @@ public class CleanCommand implements Action {
 			        for (WorkflowTask task : tasks) {
 			                try {
 			                    processWorkflowTask(task, session);
-			                } catch (Exception e) {
+			                } catch (RuntimeException e) { // skip one bad task; a checked RepositoryException (dead session) propagates to abort the batch
 			                    LOGGER.warn("Skipping task {}: processing failed", task.getId(), e);
 			                }
 			        }
@@ -84,7 +84,6 @@ public class CleanCommand implements Action {
 			});
     }
 
-    @SuppressWarnings("unchecked")
     private static void processWorkflowTask(WorkflowTask task, JCRSessionWrapper session) throws RepositoryException {
         Workflow w = WorkflowService.getInstance().getWorkflow(task.getProvider(), task.getProcessId(), Locale.ENGLISH);
         Object raw = w.getVariables().get("nodeIds");

--- a/src/main/java/org/jahia/community/workflowtaskscleaner/CleanCommand.java
+++ b/src/main/java/org/jahia/community/workflowtaskscleaner/CleanCommand.java
@@ -73,17 +73,28 @@ public class CleanCommand implements Action {
 			    	JahiaUser user = session.getUser();
 			        List<WorkflowTask> tasks = WorkflowService.getInstance().getTasksForUser(user, Locale.ENGLISH);
 			        for (WorkflowTask task : tasks) {
-			            processWorkflowTask(task, session);
+			                try {
+			                    processWorkflowTask(task, session);
+			                } catch (Exception e) {
+			                    LOGGER.warn("Skipping task {}: processing failed", task.getId(), e);
+			                }
 			        }
 					return null;
 				}
 			});
     }
 
+    @SuppressWarnings("unchecked")
     private static void processWorkflowTask(WorkflowTask task, JCRSessionWrapper session) throws RepositoryException {
         Workflow w = WorkflowService.getInstance().getWorkflow(task.getProvider(), task.getProcessId(), Locale.ENGLISH);
-        List<String> nodeIds = (List<String>) w.getVariables().get("nodeIds");
-        if (nodeIds != null && !hasExistingNodes(nodeIds, session)) {
+        Object raw = w.getVariables().get("nodeIds");
+        if (!(raw instanceof List)) {
+            LOGGER.warn("Skipping workflow {}: nodeIds missing or not a List", w.getId());
+            return;
+        }
+        @SuppressWarnings("unchecked")
+        List<String> nodeIds = (List<String>) raw;
+        if (!hasExistingNodes(nodeIds, session)) {
             WorkflowService.getInstance().abortProcess(w.getId(), w.getProvider());
         }
     }

--- a/src/main/java/org/jahia/community/workflowtaskscleaner/WorkflowListCommand.java
+++ b/src/main/java/org/jahia/community/workflowtaskscleaner/WorkflowListCommand.java
@@ -103,16 +103,16 @@ public class WorkflowListCommand implements Action {
             jbpmServicesPersistenceManagerField.setAccessible(true);
             JbpmServicesPersistenceManager jbpmServicesPersistenceManager = (JbpmServicesPersistenceManager) jbpmServicesPersistenceManagerField.get(jBPM);
             jbpmServicesPersistenceManager.beginTransaction();
-            
-            List<String> instanceIds = listAllWorkflowInstances(runtimeEngine, locale);
-            listWorkflowInstancesForUser(runtimeEngine, locale);
-            listTasksForUser(runtimeEngine, locale);
-            listTasksByStatus(runtimeEngine, locale);
-            listAllTasksByProcess(runtimeEngine, instanceIds);
-            
-            jbpmServicesPersistenceManager.endTransaction(false);
+            try {
+                List<String> instanceIds = listAllWorkflowInstances(runtimeEngine, locale);
+                listWorkflowInstancesForUser(runtimeEngine, locale);
+                listTasksForUser(runtimeEngine, locale);
+                listTasksByStatus(runtimeEngine, locale);
+                listAllTasksByProcess(runtimeEngine, instanceIds);
+            } finally {
+                jbpmServicesPersistenceManager.endTransaction(false);
+            }
         } catch (IllegalAccessException | NoSuchFieldException e) {
-            Thread.currentThread().interrupt();
             LOGGER.error("Failed to access workflow fields", e);
             throw new IllegalStateException("Failed to access workflow fields", e);
         }

--- a/src/main/java/org/jahia/community/workflowtaskscleaner/WorkflowTaskCommand.java
+++ b/src/main/java/org/jahia/community/workflowtaskscleaner/WorkflowTaskCommand.java
@@ -123,7 +123,6 @@ public class WorkflowTaskCommand implements Action {
                 jbpmServicesPersistenceManager.endTransaction(true);
             }
         } catch (IllegalAccessException | NoSuchFieldException | SQLException | RepositoryException e) {
-            Thread.currentThread().interrupt();
             LOGGER.error("Failed to execute task command", e);
             throw new IllegalStateException("Failed to execute task command", e);
         }

--- a/src/main/java/org/jahia/community/workflowtaskscleaner/WorkflowTasksCleanerScheduler.java
+++ b/src/main/java/org/jahia/community/workflowtaskscleaner/WorkflowTasksCleanerScheduler.java
@@ -25,6 +25,7 @@ public class WorkflowTasksCleanerScheduler {
     private static final String JOB_NAME = "WorkflowTasksCleanerJob";
     private static final String TRIGGER_NAME = "WorkflowTasksCleanerJobTrigger";
     private static final String GROUP = "Maintenance";
+    public static final String DEFAULT_CRON_EXPRESSION = "0 30 2 * * ?";
 
     @Reference
     private Scheduler scheduler;
@@ -82,6 +83,6 @@ public class WorkflowTasksCleanerScheduler {
     @interface Config {
 
         @AttributeDefinition(name = "Cron expression", description = "Cron expression for the cleanup job")
-        String cronExpression() default "0 30 2 * * ?";
+        String cronExpression() default DEFAULT_CRON_EXPRESSION;
     }
 }

--- a/src/main/java/org/jahia/community/workflowtaskscleaner/graphql/WorkflowTasksCleanerMutationExtension.java
+++ b/src/main/java/org/jahia/community/workflowtaskscleaner/graphql/WorkflowTasksCleanerMutationExtension.java
@@ -54,7 +54,7 @@ public class WorkflowTasksCleanerMutationExtension {
 
     @GraphQLField
     @GraphQLName("workflowTasksCleanerSaveConfig")
-    @GraphQLDescription("Saves the workflow tasks cleaner scheduled job configuration. A module restart is required for schedule changes to take effect.")
+    @GraphQLDescription("Saves the workflow tasks cleaner scheduled job configuration. The job is rescheduled automatically when the configuration is updated.")
     @GraphQLRequiresPermission("admin")
     public static Boolean saveConfig(
             @GraphQLName("cronExpression")

--- a/src/main/java/org/jahia/community/workflowtaskscleaner/graphql/WorkflowTasksCleanerQueryExtension.java
+++ b/src/main/java/org/jahia/community/workflowtaskscleaner/graphql/WorkflowTasksCleanerQueryExtension.java
@@ -13,6 +13,7 @@ import org.jahia.services.workflow.WorkflowService;
 import org.jahia.settings.SettingsBean;
 import org.osgi.service.cm.Configuration;
 import org.osgi.service.cm.ConfigurationAdmin;
+import org.jahia.community.workflowtaskscleaner.WorkflowTasksCleanerScheduler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -38,7 +39,7 @@ public class WorkflowTasksCleanerQueryExtension {
     public static GqlConfig config() {
         ConfigurationAdmin configAdmin = BundleUtils.getOsgiService(ConfigurationAdmin.class, null);
         if (configAdmin == null) {
-            return new GqlConfig("0 30 2 * * ?");
+            return new GqlConfig(WorkflowTasksCleanerScheduler.DEFAULT_CRON_EXPRESSION);
         }
         try {
             Configuration config = configAdmin.getConfiguration(CONFIG_PID, null);
@@ -48,10 +49,10 @@ public class WorkflowTasksCleanerQueryExtension {
                     return new GqlConfig(cron.toString());
                 }
             }
-        } catch (Exception e) {
+        } catch (java.io.IOException e) {
             LOGGER.error("Failed to read configuration", e);
         }
-        return new GqlConfig("0 30 2 * * ?");
+        return new GqlConfig(WorkflowTasksCleanerScheduler.DEFAULT_CRON_EXPRESSION);
     }
 
     @GraphQLField

--- a/src/test/java/org/jahia/community/workflowtaskscleaner/WorkflowStatusTest.java
+++ b/src/test/java/org/jahia/community/workflowtaskscleaner/WorkflowStatusTest.java
@@ -1,0 +1,103 @@
+package org.jahia.community.workflowtaskscleaner;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Unit tests for the WorkflowStatus enum declared inside WorkflowListCommand.
+ */
+public class WorkflowStatusTest {
+
+    @Test
+    public void fromValue_shouldReturnPending_whenValueIsZero() {
+        WorkflowListCommand.WorkflowStatus status = WorkflowListCommand.WorkflowStatus.fromValue(0);
+        assertThat(status).isEqualTo(WorkflowListCommand.WorkflowStatus.STATE_PENDING);
+    }
+
+    @Test
+    public void fromValue_shouldReturnActive_whenValueIsOne() {
+        WorkflowListCommand.WorkflowStatus status = WorkflowListCommand.WorkflowStatus.fromValue(1);
+        assertThat(status).isEqualTo(WorkflowListCommand.WorkflowStatus.STATE_ACTIVE);
+    }
+
+    @Test
+    public void fromValue_shouldReturnCompleted_whenValueIsTwo() {
+        WorkflowListCommand.WorkflowStatus status = WorkflowListCommand.WorkflowStatus.fromValue(2);
+        assertThat(status).isEqualTo(WorkflowListCommand.WorkflowStatus.STATE_COMPLETED);
+    }
+
+    @Test
+    public void fromValue_shouldReturnAborted_whenValueIsThree() {
+        WorkflowListCommand.WorkflowStatus status = WorkflowListCommand.WorkflowStatus.fromValue(3);
+        assertThat(status).isEqualTo(WorkflowListCommand.WorkflowStatus.STATE_ABORTED);
+    }
+
+    @Test
+    public void fromValue_shouldReturnSuspended_whenValueIsFour() {
+        WorkflowListCommand.WorkflowStatus status = WorkflowListCommand.WorkflowStatus.fromValue(4);
+        assertThat(status).isEqualTo(WorkflowListCommand.WorkflowStatus.STATE_SUSPENDED);
+    }
+
+    @Test
+    public void fromValue_shouldThrowIllegalArgumentException_whenValueIsInvalid() {
+        assertThatThrownBy(() -> WorkflowListCommand.WorkflowStatus.fromValue(99))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("99");
+    }
+
+    @Test
+    public void fromValue_shouldThrowIllegalArgumentException_whenValueIsNegative() {
+        assertThatThrownBy(() -> WorkflowListCommand.WorkflowStatus.fromValue(-1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("-1");
+    }
+
+    @Test
+    public void getDescriptionByValue_shouldReturnPending_forZero() {
+        assertThat(WorkflowListCommand.WorkflowStatus.getDescriptionByValue(0)).isEqualTo("Pending");
+    }
+
+    @Test
+    public void getDescriptionByValue_shouldReturnActive_forOne() {
+        assertThat(WorkflowListCommand.WorkflowStatus.getDescriptionByValue(1)).isEqualTo("Active");
+    }
+
+    @Test
+    public void getDescriptionByValue_shouldReturnCompleted_forTwo() {
+        assertThat(WorkflowListCommand.WorkflowStatus.getDescriptionByValue(2)).isEqualTo("Completed");
+    }
+
+    @Test
+    public void getDescriptionByValue_shouldReturnAborted_forThree() {
+        assertThat(WorkflowListCommand.WorkflowStatus.getDescriptionByValue(3)).isEqualTo("Aborted");
+    }
+
+    @Test
+    public void getDescriptionByValue_shouldReturnSuspended_forFour() {
+        assertThat(WorkflowListCommand.WorkflowStatus.getDescriptionByValue(4)).isEqualTo("Suspended");
+    }
+
+    @Test
+    public void getDescriptionByValue_shouldThrowIllegalArgumentException_whenValueIsInvalid() {
+        assertThatThrownBy(() -> WorkflowListCommand.WorkflowStatus.getDescriptionByValue(999))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("999");
+    }
+
+    @Test
+    public void allEnumValues_shouldHaveMatchingFromValueRoundtrip() {
+        for (WorkflowListCommand.WorkflowStatus expected : WorkflowListCommand.WorkflowStatus.values()) {
+            WorkflowListCommand.WorkflowStatus actual = WorkflowListCommand.WorkflowStatus.fromValue(expected.getValue());
+            assertThat(actual).isEqualTo(expected);
+        }
+    }
+
+    @Test
+    public void allEnumValues_shouldHaveNonBlankDescription() {
+        for (WorkflowListCommand.WorkflowStatus status : WorkflowListCommand.WorkflowStatus.values()) {
+            assertThat(status.getDescription()).isNotBlank();
+        }
+    }
+}

--- a/src/test/java/org/jahia/community/workflowtaskscleaner/graphql/SaveConfigValidationTest.java
+++ b/src/test/java/org/jahia/community/workflowtaskscleaner/graphql/SaveConfigValidationTest.java
@@ -1,0 +1,68 @@
+package org.jahia.community.workflowtaskscleaner.graphql;
+
+import org.junit.Test;
+import org.quartz.CronExpression;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for the cron-validation branch of WorkflowTasksCleanerMutationExtension.saveConfig.
+ *
+ * These tests exercise only the validation logic that runs BEFORE any OSGi service call,
+ * so they need no mocking and no OSGi runtime.
+ *
+ * The contract under test:
+ *   - null input         → Boolean.FALSE
+ *   - empty string       → Boolean.FALSE
+ *   - invalid expression → Boolean.FALSE
+ *   - valid expression   → passes validation (CronExpression.isValidExpression returns true)
+ */
+public class SaveConfigValidationTest {
+
+    // --- replicate the guard exactly as it appears in saveConfig ---
+    private static Boolean validateCron(String cronExpression) {
+        if (cronExpression == null || cronExpression.isEmpty()
+                || !CronExpression.isValidExpression(cronExpression)) {
+            return Boolean.FALSE;
+        }
+        return Boolean.TRUE; // would proceed to OSGi call in real code
+    }
+
+    @Test
+    public void saveConfig_shouldReturnFalse_whenCronExpressionIsNull() {
+        assertThat(validateCron(null)).isFalse();
+    }
+
+    @Test
+    public void saveConfig_shouldReturnFalse_whenCronExpressionIsEmpty() {
+        assertThat(validateCron("")).isFalse();
+    }
+
+    @Test
+    public void saveConfig_shouldReturnFalse_whenCronExpressionIsNotACron() {
+        assertThat(validateCron("not a cron")).isFalse();
+    }
+
+    @Test
+    public void saveConfig_shouldReturnFalse_whenCronExpressionIsArbitraryText() {
+        assertThat(validateCron("every monday at noon")).isFalse();
+    }
+
+    @Test
+    public void saveConfig_shouldPassValidation_whenCronExpressionIsValid() {
+        // "0 30 2 * * ?" is the default; validation must accept it
+        assertThat(validateCron("0 30 2 * * ?")).isTrue();
+    }
+
+    @Test
+    public void saveConfig_shouldPassValidation_whenCronExpressionIsAnotherValidQuartzCron() {
+        // every day at midnight
+        assertThat(validateCron("0 0 0 * * ?")).isTrue();
+    }
+
+    @Test
+    public void saveConfig_shouldReturnFalse_whenCronHasTooFewFields() {
+        // Quartz requires 6 or 7 fields; 5 fields is invalid
+        assertThat(validateCron("0 30 2 * *")).isFalse();
+    }
+}

--- a/src/test/java/org/jahia/community/workflowtaskscleaner/graphql/SaveConfigValidationTest.java
+++ b/src/test/java/org/jahia/community/workflowtaskscleaner/graphql/SaveConfigValidationTest.java
@@ -6,63 +6,49 @@ import org.quartz.CronExpression;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * Tests for the cron-validation branch of WorkflowTasksCleanerMutationExtension.saveConfig.
+ * Tests for the cron-validation branch of {@link WorkflowTasksCleanerMutationExtension#saveConfig(String)}.
  *
- * These tests exercise only the validation logic that runs BEFORE any OSGi service call,
- * so they need no mocking and no OSGi runtime.
- *
- * The contract under test:
- *   - null input         → Boolean.FALSE
- *   - empty string       → Boolean.FALSE
- *   - invalid expression → Boolean.FALSE
- *   - valid expression   → passes validation (CronExpression.isValidExpression returns true)
+ * For invalid input the guard returns {@code Boolean.FALSE} BEFORE any OSGi service lookup, so the
+ * real method can be exercised directly with no mocking and no OSGi runtime. For valid input the
+ * method would proceed to a {@code ConfigurationAdmin} lookup (unavailable in a unit test), so the
+ * validity of the accepted expressions is asserted against the same predicate the guard delegates to
+ * ({@link CronExpression#isValidExpression(String)}) rather than the method's overall return value.
  */
 public class SaveConfigValidationTest {
 
-    // --- replicate the guard exactly as it appears in saveConfig ---
-    private static Boolean validateCron(String cronExpression) {
-        if (cronExpression == null || cronExpression.isEmpty()
-                || !CronExpression.isValidExpression(cronExpression)) {
-            return Boolean.FALSE;
-        }
-        return Boolean.TRUE; // would proceed to OSGi call in real code
+    @Test
+    public void saveConfig_returnsFalse_whenCronExpressionIsNull() {
+        assertThat(WorkflowTasksCleanerMutationExtension.saveConfig(null)).isFalse();
     }
 
     @Test
-    public void saveConfig_shouldReturnFalse_whenCronExpressionIsNull() {
-        assertThat(validateCron(null)).isFalse();
+    public void saveConfig_returnsFalse_whenCronExpressionIsEmpty() {
+        assertThat(WorkflowTasksCleanerMutationExtension.saveConfig("")).isFalse();
     }
 
     @Test
-    public void saveConfig_shouldReturnFalse_whenCronExpressionIsEmpty() {
-        assertThat(validateCron("")).isFalse();
+    public void saveConfig_returnsFalse_whenCronExpressionIsNotACron() {
+        assertThat(WorkflowTasksCleanerMutationExtension.saveConfig("not a cron")).isFalse();
     }
 
     @Test
-    public void saveConfig_shouldReturnFalse_whenCronExpressionIsNotACron() {
-        assertThat(validateCron("not a cron")).isFalse();
+    public void saveConfig_returnsFalse_whenCronExpressionIsArbitraryText() {
+        assertThat(WorkflowTasksCleanerMutationExtension.saveConfig("every monday at noon")).isFalse();
     }
 
     @Test
-    public void saveConfig_shouldReturnFalse_whenCronExpressionIsArbitraryText() {
-        assertThat(validateCron("every monday at noon")).isFalse();
+    public void saveConfig_returnsFalse_whenCronHasTooFewFields() {
+        // Quartz requires 6 or 7 fields; 5 fields is invalid.
+        assertThat(WorkflowTasksCleanerMutationExtension.saveConfig("0 30 2 * *")).isFalse();
     }
 
     @Test
-    public void saveConfig_shouldPassValidation_whenCronExpressionIsValid() {
-        // "0 30 2 * * ?" is the default; validation must accept it
-        assertThat(validateCron("0 30 2 * * ?")).isTrue();
+    public void cronValidationPredicate_acceptsTheDefaultExpression() {
+        assertThat(CronExpression.isValidExpression("0 30 2 * * ?")).isTrue();
     }
 
     @Test
-    public void saveConfig_shouldPassValidation_whenCronExpressionIsAnotherValidQuartzCron() {
-        // every day at midnight
-        assertThat(validateCron("0 0 0 * * ?")).isTrue();
-    }
-
-    @Test
-    public void saveConfig_shouldReturnFalse_whenCronHasTooFewFields() {
-        // Quartz requires 6 or 7 fields; 5 fields is invalid
-        assertThat(validateCron("0 30 2 * *")).isFalse();
+    public void cronValidationPredicate_acceptsAnotherValidQuartzCron() {
+        assertThat(CronExpression.isValidExpression("0 0 0 * * ?")).isTrue();
     }
 }


### PR DESCRIPTION
## Summary

Blind review of `workflow-tasks-cleaner` (a previously un-hardened module — it had **no Java tests**). The GraphQL mutations are correctly `@GraphQLRequiresPermission("admin")` guarded (no security gap). Applied a focused set of behavior-preserving robustness fixes and added the first unit tests.

### Bug fixes
- **Spurious thread interrupt** — removed `Thread.currentThread().interrupt()` from the reflection-error catch blocks in `WorkflowListCommand` / `WorkflowTaskCommand`. The interrupt flag is only meaningful for `InterruptedException`; setting it there could corrupt later blocking calls.
- **Transaction leak** — `WorkflowListCommand.execute()` ended the jBPM transaction only on the happy path; wrapped the listing calls in `try/finally` so `endTransaction(false)` always runs.
- **One bad workflow aborted the whole scan** — `CleanCommand.cleanGhostWorkflows` now guards the `nodeIds` cast with `instanceof` and wraps per-task processing in try/catch, so a malformed workflow variable is skipped (logged) instead of failing the entire run.

### Maintainability
- Extracted `DEFAULT_CRON_EXPRESSION` (single source of truth for the scheduler default + the query fallback + the `@AttributeDefinition` default).
- Corrected the `saveConfig` GraphQL description — the scheduler is `@Modified`, so config updates reschedule automatically (no restart).
- Narrowed an over-broad `catch (Exception)` → `catch (IOException)` in the config query.

### Tests (new — module had zero)
- JUnit 4 + AssertJ: `WorkflowStatus` enum lookups (valid/invalid values) and the `saveConfig` cron-validation guard (null/empty/invalid → false). **22 tests.**

### Deferred (flagged for follow-up; out of scope for a low-risk pass)
- The mutation's `new Thread(...)` could move to a managed executor, and the `static AtomicBoolean IS_RUNNING` lacks a crash-recovery reset — left as-is to avoid an OSGi-lifecycle refactor that needs runtime verification.
- `WorkflowTaskCommand` calls `endTransaction(true)` in `finally` (always) — **please verify the jBPM semantics**: if `true` means rollback, the fix/delete commands may not persist. Left unchanged because `deleteTask` appears to use its own JDBC connection and the behavior couldn't be confirmed without a running instance.
- Deep reflection (`setAccessible`) will need `--add-opens` on Java 17+.

## Test plan
- [x] `mvn clean install sonar:sonar` — BUILD SUCCESS, **22 Java tests** pass
- [x] SonarQube quality gate **OK**, **0 open issues**
- [ ] Local Cypress not run this session (EE license inaccessible in this environment; no GitHub Cypress workflow on this repo). Backend-only changes — recommend running `tests/ci.build.sh && tests/ci.startup.sh` before merge.