### PR TITLE
refactor: nest GraphQL operations under a workflowTasksCleaner namespace container

### DIFF
--- a/src/javascript/WorkflowTasksCleaner/SchedulerConfig.jsx
+++ b/src/javascript/WorkflowTasksCleaner/SchedulerConfig.jsx
@@ -21,9 +21,9 @@ export const SchedulerConfig = () => {
     const {data, loading} = useQuery(GET_CONFIG, {fetchPolicy: 'network-only'});
 
     useEffect(() => {
-        if (data?.workflowTasksCleanerConfig) {
+        if (data?.workflowTasksCleaner?.config) {
             setForm({
-                cronExpression: data.workflowTasksCleanerConfig.cronExpression
+                cronExpression: data.workflowTasksCleaner.config.cronExpression
             });
         }
     }, [data]);
@@ -42,7 +42,7 @@ export const SchedulerConfig = () => {
                     cronExpression: form.cronExpression
                 }
             });
-            setSaveStatus(result.data?.workflowTasksCleanerSaveConfig === true ? 'success' : 'error');
+            setSaveStatus(result.data?.workflowTasksCleaner?.saveConfig === true ? 'success' : 'error');
         } catch {
             setSaveStatus('error');
         }

--- a/src/javascript/WorkflowTasksCleaner/WorkflowTasksCleaner.gql.js
+++ b/src/javascript/WorkflowTasksCleaner/WorkflowTasksCleaner.gql.js
@@ -2,31 +2,39 @@ import {gql} from '@apollo/client';
 
 export const GET_CONFIG = gql`
     query WorkflowTasksCleanerConfig {
-        workflowTasksCleanerConfig {
-            cronExpression
+        workflowTasksCleaner {
+            config {
+                cronExpression
+            }
         }
     }
 `;
 
 export const SAVE_CONFIG = gql`
     mutation WorkflowTasksCleanerSaveConfig($cronExpression: String) {
-        workflowTasksCleanerSaveConfig(cronExpression: $cronExpression)
+        workflowTasksCleaner {
+            saveConfig(cronExpression: $cronExpression)
+        }
     }
 `;
 
 export const RUN_CLEAN = gql`
     mutation WorkflowTasksCleanerRunClean {
-        workflowTasksCleanerRunClean
+        workflowTasksCleaner {
+            runClean
+        }
     }
 `;
 
 export const WORKFLOW_LIST = gql`
     query WorkflowTasksCleanerWorkflowList {
-        workflowTasksCleanerWorkflowList {
-            id
-            name
-            type
-            title
+        workflowTasksCleaner {
+            workflowList {
+                id
+                name
+                type
+                title
+            }
         }
     }
 `;

--- a/src/javascript/WorkflowTasksCleaner/WorkflowTasksCleaner.jsx
+++ b/src/javascript/WorkflowTasksCleaner/WorkflowTasksCleaner.jsx
@@ -17,7 +17,7 @@ export const WorkflowTasksCleanerAdmin = () => {
     const [loadWorkflows, {loading: loadingWorkflows}] = useLazyQuery(WORKFLOW_LIST, {
         fetchPolicy: 'network-only',
         onCompleted: data => {
-            setWorkflows(data?.workflowTasksCleanerWorkflowList || []);
+            setWorkflows(data?.workflowTasksCleaner?.workflowList || []);
         }
     });
 
@@ -32,7 +32,7 @@ export const WorkflowTasksCleanerAdmin = () => {
         setRunStatus(null);
         try {
             const result = await runClean();
-            if (result.data?.workflowTasksCleanerRunClean === true) {
+            if (result.data?.workflowTasksCleaner?.runClean === true) {
                 setRunStatus('success');
             } else {
                 setRunStatus('error');

--- a/src/main/java/org/jahia/community/workflowtaskscleaner/graphql/WorkflowTasksCleanerMutation.java
+++ b/src/main/java/org/jahia/community/workflowtaskscleaner/graphql/WorkflowTasksCleanerMutation.java
@@ -1,0 +1,80 @@
+package org.jahia.community.workflowtaskscleaner.graphql;
+
+import graphql.annotations.annotationTypes.GraphQLDescription;
+import graphql.annotations.annotationTypes.GraphQLField;
+import graphql.annotations.annotationTypes.GraphQLName;
+import org.jahia.community.workflowtaskscleaner.CleanCommand;
+import org.jahia.modules.graphql.provider.dxm.security.GraphQLRequiresPermission;
+import org.jahia.osgi.BundleUtils;
+import org.osgi.service.cm.Configuration;
+import org.osgi.service.cm.ConfigurationAdmin;
+import org.quartz.CronExpression;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Dictionary;
+import java.util.Hashtable;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+@GraphQLName("WorkflowTasksCleanerMutation")
+@GraphQLDescription("Workflow Tasks Cleaner mutations")
+public class WorkflowTasksCleanerMutation {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(WorkflowTasksCleanerMutation.class);
+    private static final String CONFIG_PID = "org.jahia.community.workflowtaskscleaner";
+    private static final AtomicBoolean IS_RUNNING = new AtomicBoolean(false);
+
+    @GraphQLField
+    @GraphQLName("runClean")
+    @GraphQLDescription("Triggers the cleanup of exited/completed workflow tasks asynchronously. Returns false if a clean is already running.")
+    @GraphQLRequiresPermission("admin")
+    public Boolean runClean() {
+        if (!IS_RUNNING.compareAndSet(false, true)) {
+            LOGGER.info("Workflow tasks cleaner run requested but already running");
+            return Boolean.FALSE;
+        }
+        new Thread(() -> {
+            try {
+                CleanCommand.deleteTasks();
+            } catch (Exception e) {
+                LOGGER.error("Failed to run workflow tasks cleaner", e);
+            } finally {
+                IS_RUNNING.set(false);
+            }
+        }).start();
+        return Boolean.TRUE;
+    }
+
+    @GraphQLField
+    @GraphQLName("saveConfig")
+    @GraphQLDescription("Saves the workflow tasks cleaner scheduled job configuration. The job is rescheduled automatically when the configuration is updated.")
+    @GraphQLRequiresPermission("admin")
+    public Boolean saveConfig(
+            @GraphQLName("cronExpression")
+            @GraphQLDescription("Quartz cron expression for the scheduled cleanup")
+            String cronExpression) {
+
+        if (cronExpression == null || cronExpression.isEmpty() || !CronExpression.isValidExpression(cronExpression)) {
+            LOGGER.warn("Invalid cron expression provided, configuration not updated");
+            return Boolean.FALSE;
+        }
+        try {
+            ConfigurationAdmin configAdmin = BundleUtils.getOsgiService(ConfigurationAdmin.class, null);
+            if (configAdmin == null) {
+                return Boolean.FALSE;
+            }
+            Configuration config = configAdmin.getConfiguration(CONFIG_PID, null);
+            Dictionary<String, Object> props = config.getProperties();
+            if (props == null) {
+                props = new Hashtable<>();
+            }
+            props.put("cronExpression", cronExpression);
+            config.update(props);
+            return Boolean.TRUE;
+        } catch (IOException e) {
+            LOGGER.error("Failed to save configuration", e);
+            return Boolean.FALSE;
+        }
+    }
+}

--- a/src/main/java/org/jahia/community/workflowtaskscleaner/graphql/WorkflowTasksCleanerMutationExtension.java
+++ b/src/main/java/org/jahia/community/workflowtaskscleaner/graphql/WorkflowTasksCleanerMutationExtension.java
@@ -4,83 +4,19 @@ import graphql.annotations.annotationTypes.GraphQLDescription;
 import graphql.annotations.annotationTypes.GraphQLField;
 import graphql.annotations.annotationTypes.GraphQLName;
 import graphql.annotations.annotationTypes.GraphQLTypeExtension;
-import org.jahia.community.workflowtaskscleaner.CleanCommand;
 import org.jahia.modules.graphql.provider.dxm.DXGraphQLProvider;
-import org.jahia.modules.graphql.provider.dxm.security.GraphQLRequiresPermission;
-import org.jahia.osgi.BundleUtils;
-import org.osgi.service.cm.Configuration;
-import org.osgi.service.cm.ConfigurationAdmin;
-import org.quartz.CronExpression;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.io.IOException;
-import java.util.Dictionary;
-import java.util.Hashtable;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 @GraphQLTypeExtension(DXGraphQLProvider.Mutation.class)
-@GraphQLName("WorkflowTasksCleanerMutations")
-@GraphQLDescription("Workflow tasks cleaner mutations")
+@GraphQLDescription("Workflow Tasks Cleaner mutations")
 public class WorkflowTasksCleanerMutationExtension {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(WorkflowTasksCleanerMutationExtension.class);
-    private static final String CONFIG_PID = "org.jahia.community.workflowtaskscleaner";
-    private static final AtomicBoolean IS_RUNNING = new AtomicBoolean(false);
 
     private WorkflowTasksCleanerMutationExtension() {
     }
 
     @GraphQLField
-    @GraphQLName("workflowTasksCleanerRunClean")
-    @GraphQLDescription("Triggers the cleanup of exited/completed workflow tasks asynchronously. Returns false if a clean is already running.")
-    @GraphQLRequiresPermission("admin")
-    public static Boolean runClean() {
-        if (!IS_RUNNING.compareAndSet(false, true)) {
-            LOGGER.info("Workflow tasks cleaner run requested but already running");
-            return Boolean.FALSE;
-        }
-        new Thread(() -> {
-            try {
-                CleanCommand.deleteTasks();
-            } catch (Exception e) {
-                LOGGER.error("Failed to run workflow tasks cleaner", e);
-            } finally {
-                IS_RUNNING.set(false);
-            }
-        }).start();
-        return Boolean.TRUE;
-    }
-
-    @GraphQLField
-    @GraphQLName("workflowTasksCleanerSaveConfig")
-    @GraphQLDescription("Saves the workflow tasks cleaner scheduled job configuration. The job is rescheduled automatically when the configuration is updated.")
-    @GraphQLRequiresPermission("admin")
-    public static Boolean saveConfig(
-            @GraphQLName("cronExpression")
-            @GraphQLDescription("Quartz cron expression for the scheduled cleanup")
-            String cronExpression) {
-
-        if (cronExpression == null || cronExpression.isEmpty() || !CronExpression.isValidExpression(cronExpression)) {
-            LOGGER.warn("Invalid cron expression provided, configuration not updated");
-            return Boolean.FALSE;
-        }
-        try {
-            ConfigurationAdmin configAdmin = BundleUtils.getOsgiService(ConfigurationAdmin.class, null);
-            if (configAdmin == null) {
-                return Boolean.FALSE;
-            }
-            Configuration config = configAdmin.getConfiguration(CONFIG_PID, null);
-            Dictionary<String, Object> props = config.getProperties();
-            if (props == null) {
-                props = new Hashtable<>();
-            }
-            props.put("cronExpression", cronExpression);
-            config.update(props);
-            return Boolean.TRUE;
-        } catch (IOException e) {
-            LOGGER.error("Failed to save configuration", e);
-            return Boolean.FALSE;
-        }
+    @GraphQLName("workflowTasksCleaner")
+    @GraphQLDescription("Workflow Tasks Cleaner mutation namespace")
+    public static WorkflowTasksCleanerMutation workflowTasksCleaner() {
+        return new WorkflowTasksCleanerMutation();
     }
 }

--- a/src/main/java/org/jahia/community/workflowtaskscleaner/graphql/WorkflowTasksCleanerQuery.java
+++ b/src/main/java/org/jahia/community/workflowtaskscleaner/graphql/WorkflowTasksCleanerQuery.java
@@ -1,0 +1,78 @@
+package org.jahia.community.workflowtaskscleaner.graphql;
+
+import graphql.annotations.annotationTypes.GraphQLDescription;
+import graphql.annotations.annotationTypes.GraphQLField;
+import graphql.annotations.annotationTypes.GraphQLName;
+import org.jahia.modules.graphql.provider.dxm.security.GraphQLRequiresPermission;
+import org.jahia.osgi.BundleUtils;
+import org.jahia.services.workflow.Workflow;
+import org.jahia.services.workflow.WorkflowDefinition;
+import org.jahia.services.workflow.WorkflowService;
+import org.jahia.settings.SettingsBean;
+import org.osgi.service.cm.Configuration;
+import org.osgi.service.cm.ConfigurationAdmin;
+import org.jahia.community.workflowtaskscleaner.WorkflowTasksCleanerScheduler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+@GraphQLName("WorkflowTasksCleanerQuery")
+@GraphQLDescription("Workflow Tasks Cleaner queries")
+public class WorkflowTasksCleanerQuery {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(WorkflowTasksCleanerQuery.class);
+    private static final String CONFIG_PID = "org.jahia.community.workflowtaskscleaner";
+
+    @GraphQLField
+    @GraphQLName("config")
+    @GraphQLDescription("Returns the current workflow tasks cleaner scheduled job configuration")
+    @GraphQLRequiresPermission("admin")
+    public GqlConfig config() {
+        ConfigurationAdmin configAdmin = BundleUtils.getOsgiService(ConfigurationAdmin.class, null);
+        if (configAdmin == null) {
+            return new GqlConfig(WorkflowTasksCleanerScheduler.DEFAULT_CRON_EXPRESSION);
+        }
+        try {
+            Configuration config = configAdmin.getConfiguration(CONFIG_PID, null);
+            if (config != null && config.getProperties() != null) {
+                Object cron = config.getProperties().get("cronExpression");
+                if (cron != null) {
+                    return new GqlConfig(cron.toString());
+                }
+            }
+        } catch (java.io.IOException e) {
+            LOGGER.error("Failed to read configuration", e);
+        }
+        return new GqlConfig(WorkflowTasksCleanerScheduler.DEFAULT_CRON_EXPRESSION);
+    }
+
+    @GraphQLField
+    @GraphQLName("workflowList")
+    @GraphQLDescription("Lists all current workflow tasks with their status")
+    @GraphQLRequiresPermission("admin")
+    public List<GqlWorkflowTask> workflowList() {
+        List<GqlWorkflowTask> result = new ArrayList<>();
+        Locale locale = SettingsBean.getInstance().getDefaultLocale();
+        try {
+            WorkflowService workflowService = WorkflowService.getInstance();
+            List<WorkflowDefinition> workflows = workflowService.getWorkflows(locale);
+            for (WorkflowDefinition workflowDefinition : workflows) {
+                List<Workflow> workflowsForType = workflowService.getWorkflowsForDefinition(workflowDefinition.getName(), locale);
+                for (Workflow w : workflowsForType) {
+                    result.add(new GqlWorkflowTask(
+                            w.getId(),
+                            w.getName(),
+                            w.getWorkflowDefinition().getDisplayName(),
+                            w.getVariables().get("jcr_title") != null ? w.getVariables().get("jcr_title").toString() : null
+                    ));
+                }
+            }
+        } catch (javax.jcr.RepositoryException e) {
+            LOGGER.error("Failed to list workflows", e);
+        }
+        return result;
+    }
+}

--- a/src/main/java/org/jahia/community/workflowtaskscleaner/graphql/WorkflowTasksCleanerQueryExtension.java
+++ b/src/main/java/org/jahia/community/workflowtaskscleaner/graphql/WorkflowTasksCleanerQueryExtension.java
@@ -5,80 +5,18 @@ import graphql.annotations.annotationTypes.GraphQLField;
 import graphql.annotations.annotationTypes.GraphQLName;
 import graphql.annotations.annotationTypes.GraphQLTypeExtension;
 import org.jahia.modules.graphql.provider.dxm.DXGraphQLProvider;
-import org.jahia.modules.graphql.provider.dxm.security.GraphQLRequiresPermission;
-import org.jahia.osgi.BundleUtils;
-import org.jahia.services.workflow.Workflow;
-import org.jahia.services.workflow.WorkflowDefinition;
-import org.jahia.services.workflow.WorkflowService;
-import org.jahia.settings.SettingsBean;
-import org.osgi.service.cm.Configuration;
-import org.osgi.service.cm.ConfigurationAdmin;
-import org.jahia.community.workflowtaskscleaner.WorkflowTasksCleanerScheduler;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Locale;
 
 @GraphQLTypeExtension(DXGraphQLProvider.Query.class)
-@GraphQLName("WorkflowTasksCleanerQueries")
-@GraphQLDescription("Workflow tasks cleaner queries")
+@GraphQLDescription("Workflow Tasks Cleaner queries")
 public class WorkflowTasksCleanerQueryExtension {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(WorkflowTasksCleanerQueryExtension.class);
-    private static final String CONFIG_PID = "org.jahia.community.workflowtaskscleaner";
 
     private WorkflowTasksCleanerQueryExtension() {
     }
 
     @GraphQLField
-    @GraphQLName("workflowTasksCleanerConfig")
-    @GraphQLDescription("Returns the current workflow tasks cleaner scheduled job configuration")
-    @GraphQLRequiresPermission("admin")
-    public static GqlConfig config() {
-        ConfigurationAdmin configAdmin = BundleUtils.getOsgiService(ConfigurationAdmin.class, null);
-        if (configAdmin == null) {
-            return new GqlConfig(WorkflowTasksCleanerScheduler.DEFAULT_CRON_EXPRESSION);
-        }
-        try {
-            Configuration config = configAdmin.getConfiguration(CONFIG_PID, null);
-            if (config != null && config.getProperties() != null) {
-                Object cron = config.getProperties().get("cronExpression");
-                if (cron != null) {
-                    return new GqlConfig(cron.toString());
-                }
-            }
-        } catch (java.io.IOException e) {
-            LOGGER.error("Failed to read configuration", e);
-        }
-        return new GqlConfig(WorkflowTasksCleanerScheduler.DEFAULT_CRON_EXPRESSION);
-    }
-
-    @GraphQLField
-    @GraphQLName("workflowTasksCleanerWorkflowList")
-    @GraphQLDescription("Lists all current workflow tasks with their status")
-    @GraphQLRequiresPermission("admin")
-    public static List<GqlWorkflowTask> workflowList() {
-        List<GqlWorkflowTask> result = new ArrayList<>();
-        Locale locale = SettingsBean.getInstance().getDefaultLocale();
-        try {
-            WorkflowService workflowService = WorkflowService.getInstance();
-            List<WorkflowDefinition> workflows = workflowService.getWorkflows(locale);
-            for (WorkflowDefinition workflowDefinition : workflows) {
-                List<Workflow> workflowsForType = workflowService.getWorkflowsForDefinition(workflowDefinition.getName(), locale);
-                for (Workflow w : workflowsForType) {
-                    result.add(new GqlWorkflowTask(
-                            w.getId(),
-                            w.getName(),
-                            w.getWorkflowDefinition().getDisplayName(),
-                            w.getVariables().get("jcr_title") != null ? w.getVariables().get("jcr_title").toString() : null
-                    ));
-                }
-            }
-        } catch (javax.jcr.RepositoryException e) {
-            LOGGER.error("Failed to list workflows", e);
-        }
-        return result;
+    @GraphQLName("workflowTasksCleaner")
+    @GraphQLDescription("Workflow Tasks Cleaner query namespace")
+    public static WorkflowTasksCleanerQuery workflowTasksCleaner() {
+        return new WorkflowTasksCleanerQuery();
     }
 }

--- a/src/test/java/org/jahia/community/workflowtaskscleaner/graphql/SaveConfigValidationTest.java
+++ b/src/test/java/org/jahia/community/workflowtaskscleaner/graphql/SaveConfigValidationTest.java
@@ -6,7 +6,7 @@ import org.quartz.CronExpression;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * Tests for the cron-validation branch of {@link WorkflowTasksCleanerMutationExtension#saveConfig(String)}.
+ * Tests for the cron-validation branch of {@link WorkflowTasksCleanerMutation#saveConfig(String)}.
  *
  * For invalid input the guard returns {@code Boolean.FALSE} BEFORE any OSGi service lookup, so the
  * real method can be exercised directly with no mocking and no OSGi runtime. For valid input the
@@ -18,28 +18,28 @@ public class SaveConfigValidationTest {
 
     @Test
     public void saveConfig_returnsFalse_whenCronExpressionIsNull() {
-        assertThat(WorkflowTasksCleanerMutationExtension.saveConfig(null)).isFalse();
+        assertThat(new WorkflowTasksCleanerMutation().saveConfig(null)).isFalse();
     }
 
     @Test
     public void saveConfig_returnsFalse_whenCronExpressionIsEmpty() {
-        assertThat(WorkflowTasksCleanerMutationExtension.saveConfig("")).isFalse();
+        assertThat(new WorkflowTasksCleanerMutation().saveConfig("")).isFalse();
     }
 
     @Test
     public void saveConfig_returnsFalse_whenCronExpressionIsNotACron() {
-        assertThat(WorkflowTasksCleanerMutationExtension.saveConfig("not a cron")).isFalse();
+        assertThat(new WorkflowTasksCleanerMutation().saveConfig("not a cron")).isFalse();
     }
 
     @Test
     public void saveConfig_returnsFalse_whenCronExpressionIsArbitraryText() {
-        assertThat(WorkflowTasksCleanerMutationExtension.saveConfig("every monday at noon")).isFalse();
+        assertThat(new WorkflowTasksCleanerMutation().saveConfig("every monday at noon")).isFalse();
     }
 
     @Test
     public void saveConfig_returnsFalse_whenCronHasTooFewFields() {
         // Quartz requires 6 or 7 fields; 5 fields is invalid.
-        assertThat(WorkflowTasksCleanerMutationExtension.saveConfig("0 30 2 * *")).isFalse();
+        assertThat(new WorkflowTasksCleanerMutation().saveConfig("0 30 2 * *")).isFalse();
     }
 
     @Test

--- a/tests/cypress/e2e/01-workflowTasksCleanerAPI.cy.ts
+++ b/tests/cypress/e2e/01-workflowTasksCleanerAPI.cy.ts
@@ -19,7 +19,7 @@ describe('Workflow Tasks Cleaner - GraphQL API', () => {
     describe('workflowTasksCleanerConfig', () => {
         it('returns all config fields', () => {
             cy.apollo({query: getConfig})
-                .its('data.workflowTasksCleanerConfig')
+                .its('data.workflowTasksCleaner.config')
                 .should(config => {
                     expect(config).to.have.property('cronExpression');
                 });
@@ -27,7 +27,7 @@ describe('Workflow Tasks Cleaner - GraphQL API', () => {
 
         it('returns cronExpression as a non-empty string', () => {
             cy.apollo({query: getConfig})
-                .its('data.workflowTasksCleanerConfig.cronExpression')
+                .its('data.workflowTasksCleaner.config.cronExpression')
                 .should('be.a', 'string')
                 .and('not.be.empty');
         });
@@ -42,11 +42,11 @@ describe('Workflow Tasks Cleaner - GraphQL API', () => {
                 mutation: saveConfig,
                 variables: {cronExpression: cron}
             })
-                .its('data.workflowTasksCleanerSaveConfig')
+                .its('data.workflowTasksCleaner.saveConfig')
                 .should('eq', true);
 
             cy.apollo({query: getConfig})
-                .its('data.workflowTasksCleanerConfig.cronExpression')
+                .its('data.workflowTasksCleaner.config.cronExpression')
                 .should('eq', cron);
         });
 
@@ -55,7 +55,7 @@ describe('Workflow Tasks Cleaner - GraphQL API', () => {
                 mutation: saveConfig,
                 variables: {cronExpression: '0 30 2 * * ?'}
             })
-                .its('data.workflowTasksCleanerSaveConfig')
+                .its('data.workflowTasksCleaner.saveConfig')
                 .should('eq', true);
         });
     });
@@ -65,7 +65,7 @@ describe('Workflow Tasks Cleaner - GraphQL API', () => {
     describe('workflowTasksCleanerRunClean', () => {
         it('triggers cleanup and returns true', () => {
             cy.apollo({mutation: runClean})
-                .its('data.workflowTasksCleanerRunClean')
+                .its('data.workflowTasksCleaner.runClean')
                 .should('eq', true);
         });
     });
@@ -75,13 +75,13 @@ describe('Workflow Tasks Cleaner - GraphQL API', () => {
     describe('workflowTasksCleanerWorkflowList', () => {
         it('returns a list (may be empty)', () => {
             cy.apollo({query: workflowList})
-                .its('data.workflowTasksCleanerWorkflowList')
+                .its('data.workflowTasksCleaner.workflowList')
                 .should('be.an', 'array');
         });
 
         it('returns workflow objects with expected fields', () => {
             cy.apollo({query: workflowList})
-                .its('data.workflowTasksCleanerWorkflowList')
+                .its('data.workflowTasksCleaner.workflowList')
                 .should(wfs => {
                     if (wfs.length > 0) {
                         expect(wfs[0]).to.have.property('id');

--- a/tests/cypress/e2e/03-workflowTasksCleanerConfiguration.cy.ts
+++ b/tests/cypress/e2e/03-workflowTasksCleanerConfiguration.cy.ts
@@ -55,7 +55,7 @@ describe('Workflow Tasks Cleaner - Configuration UI', () => {
         cy.get('[class*="wtc_alert--success"]', {timeout: 10000}).should('be.visible');
 
         cy.apollo({query: getConfig})
-            .its('data.workflowTasksCleanerConfig.cronExpression')
+            .its('data.workflowTasksCleaner.config.cronExpression')
             .should('eq', cron);
     });
 

--- a/tests/cypress/fixtures/graphql/mutation/runClean.graphql
+++ b/tests/cypress/fixtures/graphql/mutation/runClean.graphql
@@ -1,3 +1,5 @@
 mutation WorkflowTasksCleanerRunClean {
-    workflowTasksCleanerRunClean
+    workflowTasksCleaner {
+        runClean
+    }
 }

--- a/tests/cypress/fixtures/graphql/mutation/saveConfig.graphql
+++ b/tests/cypress/fixtures/graphql/mutation/saveConfig.graphql
@@ -1,3 +1,5 @@
 mutation WorkflowTasksCleanerSaveConfig($cronExpression: String) {
-    workflowTasksCleanerSaveConfig(cronExpression: $cronExpression)
+    workflowTasksCleaner {
+        saveConfig(cronExpression: $cronExpression)
+    }
 }

--- a/tests/cypress/fixtures/graphql/query/getConfig.graphql
+++ b/tests/cypress/fixtures/graphql/query/getConfig.graphql
@@ -1,5 +1,7 @@
 query {
-    workflowTasksCleanerConfig {
-        cronExpression
+    workflowTasksCleaner {
+        config {
+            cronExpression
+        }
     }
 }

--- a/tests/cypress/fixtures/graphql/query/workflowList.graphql
+++ b/tests/cypress/fixtures/graphql/query/workflowList.graphql
@@ -1,8 +1,10 @@
 query {
-    workflowTasksCleanerWorkflowList {
-        id
-        name
-        type
-        title
+    workflowTasksCleaner {
+        workflowList {
+            id
+            name
+            type
+            title
+        }
     }
 }


### PR DESCRIPTION
## What & why
Brings the module in line with the Jahia GraphQL convention: group operations under **one hierarchical namespace container** instead of flat, prefix-named root fields.

### Schema change (breaking)
```graphql
# before: query { workflowTasksCleanerConfig { ... } }   mutation { workflowTasksCleanerRunClean }
# after:  query { workflowTasksCleaner { config { ... } } }  mutation { workflowTasksCleaner { runClean } }
```

### How
- New holder types `WorkflowTasksCleanerQuery` / `WorkflowTasksCleanerMutation` hold the operations as instance `@GraphQLField` methods (`config`, `workflowList`, `runClean`, `saveConfig`); `GqlConfig`/`GqlWorkflowTask` return types are separate files (unchanged).
- The `*Extension` classes keep a single `workflowTasksCleaner` accessor field.
- `@GraphQLRequiresPermission` stays on each leaf — authorization unchanged.
- `SaveConfigValidationTest` repointed to the instance `saveConfig` on the holder.
- Frontend (`*.gql.js`/`.jsx`) and Cypress fixtures/specs updated in lockstep.

## Verification
- `mvn clean install` (JDK17): **BUILD SUCCESS**, 22 JUnit tests pass, webpack OK
- Cypress E2E: **21/21 pass** (API, execution, configuration)
- SonarQube quality gate: **OK** (0 new issues, 0 duplication)